### PR TITLE
Add buildx support in github actions to release arm64 and armv7 images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,26 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login do docker.io
+        run: docker login -u ${USERNAME} -p ${PASSWORD}
+      - name: build and publish image
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./3.10.1
+          file: ./3.10.1/Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/arm
+          push: true
+          tags: |
+            ${USERNAME}/iperf-server-v3.10.1:latest


### PR DESCRIPTION
The following file has been created and modified:
Added buildx support in github actions to release arm64 and armv7 images

Signed-off-by: odidev odidev@puresoftware.com